### PR TITLE
Remove artist check

### DIFF
--- a/lib/podcast.rb
+++ b/lib/podcast.rb
@@ -79,7 +79,6 @@ module Podcast
         end
 
         for mp3 in @mp3s 
-          next if ! mp3.artist
           item = m.items.new_item
           item.title = mp3
           ## add a base url 


### PR DESCRIPTION
My use case is to download mp3s of conference talks or pull down mp3s from youtube videos of conference talks. In these cases there is no artist information and having to go edit the mp3s just to add this information is a pain. I'm not sure what the original use case was for this check but it would greatly benefit my use case to remove it.
